### PR TITLE
chore(deps): update typings to v1.0.4

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -259,7 +259,7 @@ gulp.task('clean.code', function (done) {
 });
 
 function ts2js(path, dest, toSystem, withDeclaration) {
-  var tsResult = gulp.src(path.concat(['typings/main.d.ts', 'src/angular2-react-native.d.ts']), {base: './'})
+  var tsResult = gulp.src(path.concat(['typings/index.d.ts', 'src/angular2-react-native.d.ts']), {base: './'})
     .pipe(typescript({
       noImplicitAny: true,
       module: toSystem ? 'system' : 'commonjs',

--- a/typings.json
+++ b/typings.json
@@ -1,5 +1,5 @@
 {
-  "ambientDependencies": {
+  "globalDependencies": {
     "es6-shim": "github:DefinitelyTyped/DefinitelyTyped/es6-shim/es6-shim.d.ts#4de74cb527395c13ba20b438c3a7a419ad931f1c",
     "jasmine": "github:DefinitelyTyped/DefinitelyTyped/jasmine/jasmine.d.ts#dd638012d63e069f2c99d06ef4dcc9616a943ee4",
     "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#20e1eb9616922d382d918cc5a21870a9dbe255f5",


### PR DESCRIPTION
Usages of `ambient` are now `global`: https://www.npmjs.com/package/typings