### PR TITLE
Fix @RouteConfig replacing as to name

### DIFF
--- a/doc/pages/router.jade
+++ b/doc/pages/router.jade
@@ -52,8 +52,8 @@ block content
 
 
         @RouteConfig([
-          { path: '/', component: CompA, as: 'CompA' },
-          { path: '/b', component: CompB, as: 'CompB' },
+          { path: '/', component: CompA, name: 'CompA' },
+          { path: '/b', component: CompB, name: 'CompB' },
         ])
         @Component({
           selector: 'example',

--- a/src/components/ios/navigator.ts
+++ b/src/components/ios/navigator.ts
@@ -121,8 +121,8 @@ class Bar {}
 var moreLogo = require('../../assets/icon_more.png');
 
 @RouteConfig([
- { path: '/', component: Foo, as: 'Foo', data: {title: 'foo!', rightButtonIcon: moreLogo, backButtonTitle: 'back'}},
- { path: '/bar', component: Bar, as: 'Bar', data: {title: 'bar!'} }
+ { path: '/', component: Foo, name: 'Foo', data: {title: 'foo!', rightButtonIcon: moreLogo, backButtonTitle: 'back'}},
+ { path: '/bar', component: Bar, name: 'Bar', data: {title: 'bar!'} }
 ])
 @Component({
   selector: 'sample',


### PR DESCRIPTION
I was having the issue `Component "Example" has no route named "CompB".`, after replace `as` with `name`, my router worked it.