### PR TITLE
Fix bootstrap CDN link in docs for HTTPS users

### DIFF
--- a/doc/pages/_layout.jade
+++ b/doc/pages/_layout.jade
@@ -5,7 +5,7 @@ html(lang=en)
         meta(http-equiv="X-UA-Compatible" content="IE=edge")
         meta(name="viewport" content="width=device-width, initial-scale=1")
         title react-native-renderer
-        link(rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css")
+        link(rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css")
         style(type='text/css').
             body {
                 padding-top: 50px;


### PR DESCRIPTION
This pull request updates the URL the docs use for their stylesheet to be protocol-relative, as right now the docs' styles are broken if you are using HTTPS Everywhere.